### PR TITLE
Added support for expected output to come on stderr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -148,9 +148,10 @@ fn test_result(tc_output: &Output, t_file_path: &Path, result_dir: &Path) -> Res
       if let Ok(mut handle) = out_file {
          handle.read_to_end(&mut contents).unwrap();
          let prog_output = Command::new(prog_path.clone()).output().unwrap();
-         if prog_output.stdout != contents {
+         if prog_output.stdout != contents && prog_output.stderr != contents {
             let desired_result_text = String::from_utf8_lossy(&contents);
-            let prog_out_text = String::from_utf8_lossy(&prog_output.stdout);
+            let prog_out_text = String::from_utf8_lossy(&prog_output.stdout)
+                 + String::from_utf8_lossy(&prog_output.stderr);
             let changeset = Changeset::new(&desired_result_text, &prog_out_text, "\n");
             return Err(TestFailureReason::MismatchedExecutionOutput(changeset));
          }


### PR DESCRIPTION
I was having an issue using the test runner for my own tests, so I took the liberty of tweaking it slightly.

The various run-time errors (null reference, etc.) are supposed to be on stderr, not stdout. This adds support for comparing stderr against a test's .out file as well.

You'll need to have test cases that only output on one of sterr, stdout, though. If you think it's important, I'd be happy to change this contribution to check separate .stderr files, for example.

You didn't include a license with this project, which technically means that you have copyright, and I'm not allowed to even make this modification and suggest it. I assume that you won't sue me for copyright infringement, though. Please consider releasing this under an Open Source license. GPL or Apache are both good choices.